### PR TITLE
feat: add CompareHandler for side-by-side code comparison blocks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,9 @@ pub use reqs::{
 #[cfg(feature = "highlight")]
 pub use handlers::ArboriumHandler;
 
+#[cfg(feature = "highlight")]
+pub use handlers::{CompareHandler, CompareSection};
+
 #[cfg(feature = "aasvg")]
 pub use handlers::AasvgHandler;
 


### PR DESCRIPTION
## Summary

Adds support for side-by-side code comparison blocks in markdown using the `compare` language identifier. This is particularly useful for documentation that compares equivalent code in different languages/formats (e.g., JSON ↔ STYX comparisons).

## Changes

- **CompareHandler**: New code block handler that parses `/// language` separators and renders sections side-by-side with syntax highlighting
- **CompareSection**: Struct representing a parsed section with language and code content
- Exports `CompareHandler` and `CompareSection` (feature-gated on `highlight`)
- Full test coverage for parsing and rendering

## Usage

```markdown
```compare
/// json
{"server": {"host": "localhost", "port": 8080}}
/// styx
server host=localhost port=8080
```
```

Register with:
```rust
let opts = RenderOptions::new()
    .with_handler(&["compare"], CompareHandler::new());
```

## HTML Output

Renders as a `<div class="compare-container">` with each section in a `<div class="compare-section">`. Consumers can style with CSS (e.g., `display: flex` for side-by-side layout).

Fixes #1