### PR TITLE
Fix pikru 1.2.1 handler compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1](https://github.com/bearcove/marq/compare/v4.0.0...v4.0.1) - 2026-05-25
+
+### Fixed
+
+- Build the `pikru` feature with `pikru` 1.2.1.
+
 ## [4.0.0](https://github.com/bearcove/marq/compare/v3.0.0...v4.0.0) - 2026-05-25
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,36 +890,13 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c578b0cf6efa3459c6ff5f9f67ddfa668ba778fdbf301a1ba6bb493bf32aba"
-dependencies = [
- "autocfg",
- "facet-core 0.44.1",
- "facet-macros 0.44.1",
-]
-
-[[package]]
-name = "facet"
 version = "0.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa36099ca72f6fb53a63284034ecc747901103cc9ff2c37a3395056ff7bbae12"
 dependencies = [
  "autocfg",
- "facet-core 0.46.3",
- "facet-macros 0.46.3",
-]
-
-[[package]]
-name = "facet-core"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2c09e5a796b8989e7555cbe097ddd3c3ffa4c02392b9b4ad0d7cd48b1af5c2"
-dependencies = [
- "autocfg",
- "const-fnv1a-hash",
- "iddqd 0.3.17",
- "impls",
+ "facet-core",
+ "facet-macros",
 ]
 
 [[package]]
@@ -930,18 +907,8 @@ checksum = "6691a60d328fa343c3bc34bb2dd2778f402b98aa774d52829a3d0572bcb98815"
 dependencies = [
  "autocfg",
  "const-fnv1a-hash",
- "iddqd 0.4.1",
+ "iddqd",
  "impls",
-]
-
-[[package]]
-name = "facet-dessert"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64092a2ececf59431c1b98561ba12e308c20185185fedc8c5396468e87573435"
-dependencies = [
- "facet-core 0.44.1",
- "facet-reflect 0.44.1",
 ]
 
 [[package]]
@@ -950,19 +917,19 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4505ec8ef086d776fd99b86fb17e3d1c711188d27aa72845e64a30146226e3b"
 dependencies = [
- "facet-core 0.46.3",
- "facet-reflect 0.46.3",
+ "facet-core",
+ "facet-reflect",
 ]
 
 [[package]]
 name = "facet-dom"
-version = "0.44.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38cdfbea280cf7e0adcbbf40cff7b9fbfae1148a8e11b4fd4adb99e98a9aa53"
+checksum = "bad3bd4bd603996bd095e75d08c0da6c70bc5a394bdcd5d8f689374683eec656"
 dependencies = [
- "facet-core 0.44.1",
- "facet-dessert 0.44.1",
- "facet-reflect 0.44.1",
+ "facet-core",
+ "facet-dessert",
+ "facet-reflect",
  "facet-singularize",
  "heck",
  "owo-colors",
@@ -974,22 +941,11 @@ version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2353807588cc4057a5e31bf459e7304ea84729ad77080e267928b1e09d36235"
 dependencies = [
- "facet-core 0.46.3",
- "facet-dessert 0.46.0",
- "facet-path 0.46.3",
- "facet-reflect 0.46.3",
+ "facet-core",
+ "facet-dessert",
+ "facet-path",
+ "facet-reflect",
  "facet-solver",
-]
-
-[[package]]
-name = "facet-macro-parse"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ecddfa2b01f0ea083571f9cbb945222bc6603ce2c1cad9105eb8a432e09298"
-dependencies = [
- "facet-macro-types 0.44.1",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -998,20 +954,9 @@ version = "0.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "671db275c95fe788e8c488e72221f55b78863dec510a48131b4517ba398f716a"
 dependencies = [
- "facet-macro-types 0.46.3",
+ "facet-macro-types",
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "facet-macro-types"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22ff06d4c4bb3cc6cfaf51d20c66444d7845ab047a7cd500b2677f01a9f6fd9"
-dependencies = [
- "proc-macro2",
- "quote",
- "unsynn",
 ]
 
 [[package]]
@@ -1027,34 +972,11 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd4fe21b304e67937988fd88ef0907453a11921597fddff8ea8dc711575bfc7"
-dependencies = [
- "facet-macros-impl 0.44.1",
-]
-
-[[package]]
-name = "facet-macros"
 version = "0.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f8e1bfcea82611508c06b670ec34e7957827fefc02a0982eee2e75002ee05d"
 dependencies = [
- "facet-macros-impl 0.46.3",
-]
-
-[[package]]
-name = "facet-macros-impl"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b050ae34e587b27fa45e33720722be8ccc20a3d64f4560882cffae1ce65c564f"
-dependencies = [
- "facet-macro-parse 0.44.1",
- "facet-macro-types 0.44.1",
- "proc-macro2",
- "quote",
- "strsim",
- "unsynn",
+ "facet-macros-impl",
 ]
 
 [[package]]
@@ -1063,8 +985,8 @@ version = "0.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7517702043f5656a6ee7de64bf8b26a549dbbfe983f592be29bead7ff380d798"
 dependencies = [
- "facet-macro-parse 0.46.3",
- "facet-macro-types 0.46.3",
+ "facet-macro-parse",
+ "facet-macro-types",
  "proc-macro2",
  "quote",
  "strsim",
@@ -1073,20 +995,11 @@ dependencies = [
 
 [[package]]
 name = "facet-path"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ae380f4553db1a2ab33fb75035e7d86c178f384c4ded2e1681daec58cbbfc2"
-dependencies = [
- "facet-core 0.44.1",
-]
-
-[[package]]
-name = "facet-path"
 version = "0.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c7ec0955c6ed58229b136c1c8c5b9d9c93d7af4317b8f7a570bda726243c626"
 dependencies = [
- "facet-core 0.46.3",
+ "facet-core",
 ]
 
 [[package]]
@@ -1095,25 +1008,12 @@ version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46d8c0d08c0294d3991e6b853038935bb0f89667652439050cf3fdedcded8451"
 dependencies = [
- "facet-core 0.46.3",
+ "facet-core",
  "facet-format",
- "facet-path 0.46.3",
- "facet-reflect 0.46.3",
+ "facet-path",
+ "facet-reflect",
  "facet-value",
  "tracing",
-]
-
-[[package]]
-name = "facet-reflect"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2469bdb237a3f3cac3077b784e86be88e379534ff9322d53b3d673e27bcb0988"
-dependencies = [
- "facet-core 0.44.1",
- "facet-path 0.44.1",
- "hashbrown 0.16.1",
- "regex",
- "smallvec 2.0.0-alpha.12",
 ]
 
 [[package]]
@@ -1122,17 +1022,18 @@ version = "0.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "304dd81b64f2f759735e9044c6cb2c8b9e5ad7d004bdf1b27dd7b2f2285c0e3e"
 dependencies = [
- "facet-core 0.46.3",
- "facet-path 0.46.3",
+ "facet-core",
+ "facet-path",
  "hashbrown 0.17.1",
+ "regex",
  "smallvec 2.0.0-alpha.12",
 ]
 
 [[package]]
 name = "facet-singularize"
-version = "0.44.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e807d36cd1a467a411ff1089afd1818af7aec447f38f05e0cf3ca1d4d71147a0"
+checksum = "1fa13541c3bdca7da541e626369d6a9626429067188cf1074a2ea282ffdcc301"
 
 [[package]]
 name = "facet-solver"
@@ -1140,18 +1041,18 @@ version = "0.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16981fb80d2946389bc2dd3789e53c6f5cf1be3f25186f66f8582f748a03adf0"
 dependencies = [
- "facet-core 0.46.3",
- "facet-reflect 0.46.3",
+ "facet-core",
+ "facet-reflect",
  "strsim",
 ]
 
 [[package]]
 name = "facet-svg"
-version = "0.44.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f373ce237f5585a3bc2d2383e63e2dde8ce12d272ee5f8dfe79d4ec4270042bd"
+checksum = "a0a849508c83c55916fbf1e9f569f6f5ee523cb564d068a7499966038d34eb39"
 dependencies = [
- "facet 0.44.1",
+ "facet",
  "facet-xml",
 ]
 
@@ -1161,9 +1062,9 @@ version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5778c22ca9b91b87fae0c85edc30126d747e819284b21cbc978dff285042528d"
 dependencies = [
- "facet-core 0.46.3",
+ "facet-core",
  "facet-format",
- "facet-reflect 0.46.3",
+ "facet-reflect",
  "toml_parser",
 ]
 
@@ -1173,22 +1074,22 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c61477bcef8cda3ba1082f25ad69569792214f9d430671afb32e9cdedbce6d7"
 dependencies = [
- "facet-core 0.46.3",
+ "facet-core",
  "facet-format",
- "facet-reflect 0.46.3",
+ "facet-reflect",
  "indexmap",
 ]
 
 [[package]]
 name = "facet-xml"
-version = "0.44.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f621d4820476340d8dae6bfe49a9ebb16018c79eb303814459dc1ad9ac1eccbf"
+checksum = "dc566de3d117c51747b14e0ed6744d2b595bb8b06a374ea596a723a5b9445e86"
 dependencies = [
- "facet 0.44.1",
- "facet-core 0.44.1",
+ "facet",
+ "facet-core",
  "facet-dom",
- "facet-reflect 0.44.1",
+ "facet-reflect",
  "quick-xml",
 ]
 
@@ -1198,10 +1099,10 @@ version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14628dda60eebfbf1feeef019b63bed09143aeebbd3e22eff7ea4149e02716a"
 dependencies = [
- "facet 0.46.3",
- "facet-core 0.46.3",
+ "facet",
+ "facet-core",
  "facet-format",
- "facet-reflect 0.46.3",
+ "facet-reflect",
  "saphyr-parser",
 ]
 
@@ -1264,8 +1165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1293,19 +1192,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "iddqd"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b215e67ed1d1a4b1702acd787c487d16e4c977c5dcbcc4587bdb5ea26b6ce06"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
- "hashbrown 0.16.1",
- "rustc-hash",
-]
 
 [[package]]
 name = "iddqd"
@@ -1352,11 +1238,11 @@ dependencies = [
 
 [[package]]
 name = "marq"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "aasvg",
  "arborium",
- "facet 0.46.3",
+ "facet",
  "facet-postcard",
  "facet-toml",
  "facet-value",
@@ -1472,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "pikru"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c82374870d6348497088764ef4ad6090e7261f4dbed8dbe1de01ab1e89dcac6"
+checksum = "a8154473c77e39ab12eb47417b64629ed12d6a5da1224970c6ef31149dc09867"
 dependencies = [
  "ariadne",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marq"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Markdown rendering with pluggable code block handlers"

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -477,6 +477,7 @@ impl CodeBlockHandler for PikruHandler {
             // Render to SVG
             let options = pikru::render::RenderOptions {
                 css_variables: self.css_variables,
+                ..Default::default()
             };
             match pikru::render::render_with_options(&program, &options) {
                 Ok(svg) => Ok(svg.into()),


### PR DESCRIPTION
## Summary

Prepares marq 4.0.1 with a compatibility fix for the `pikru` feature when Cargo resolves `pikru` 1.2.1.

## Changes

- Bumps marq to 4.0.1.
- Updates the lockfile to exercise `pikru` 1.2.1 and the aligned facet dependency graph.
- Constructs `pikru::render::RenderOptions` with `..Default::default()` so marq keeps compiling after pikru added `explicit_size`.
- Adds a changelog entry for the patch release.

## Testing

- `cargo check --all-features`
- `cargo nextest run --all-features`
- `cargo clippy --all-features --all-targets --message-format=short -- -D warnings`
- `cargo doc --no-deps --all-features`
- pre-push hook: affected clippy/docs/tests
